### PR TITLE
added TensorBoard for pytorch MNIST example

### DIFF
--- a/mnist_digit_classification/mnist_pytorch.py
+++ b/mnist_digit_classification/mnist_pytorch.py
@@ -95,6 +95,8 @@ def test(model, test_dataloader, device, epoch, writer):
              )
         writer.add_scalar('Loss/Eval', test_loss, epoch)
         writer.add_scalar('Accuracy/Eval', 100.*correct/len(test_dataloader.dataset), epoch)
+        for tag, param in model.named_parameters():
+            writer.add_histogram(tag, param, epoch)
 
 
 def main():


### PR DESCRIPTION
added these:
- Scalar summaries of batch loss, batch acc at each training batch
- Scalar summaries of test loss, test acc at each epoch
- Weight histogram of trainable parameters ie conv1, conv2, fc1, fc2